### PR TITLE
Added a statement about empty methods to the style guide

### DIFF
--- a/lang/Ruby.md
+++ b/lang/Ruby.md
@@ -403,6 +403,17 @@ We've adapted this from [GitHub's Ruby style guide](https://github.com/styleguid
     regexp = Regexp.union(words)
     ```
 
+ - Treat empty methods like other methods
+
+    ```ruby
+    # bad
+    def example; end
+    
+    # good
+    def example
+    end
+    ```
+
 
 
 ## Blocks


### PR DESCRIPTION
Rubocop's recommendation is for empty methods to be on one line, e.g., `def number; end`.

I would advocate for

```ruby
def number
end
```

over

```ruby
def number; end
```

I tried the latter style for a while several years ago. (For a while any empty methods in DR and CWC were like that.) Here's why I switched:

There are two general rules in Ruby that would apply here by default:

  1. In Ruby, you _rarely_ see expressions piled up on one line like `a = 5; b = 6; c = 7`. It's far more idiomatic to put each expression on its own line.
  2. In Ruby, every `def`, `module`, `if`, and `do` requires a matching `end` and the `end`s are put in the same column as the `def`/`do`/etc that started the block (so its easy to see how they pair off — and whether you've closed enough blocks.

These conventions are so strong that, in Ruby, it's actually _weird_ to see:
 - a semicolon
 - a `def` without a matching `end` in the same column

I gave up on `def number; end` because it looked weird in Ruby — but what I really mean is: there are times when you break a convention deliberately to communicate something new; and I don't think this is one of those times: the gains of doing `def number; end` (a line of code saved? a redundant clue that the method is empty?) don't seem worth creating an exception to the general rule.